### PR TITLE
fix: firebaseNotConfigured 에러 메시지 타깃 안내 수정

### DIFF
--- a/Projects/Domain/Sources/Error/AuthError.swift
+++ b/Projects/Domain/Sources/Error/AuthError.swift
@@ -20,7 +20,7 @@ public enum AuthError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .firebaseNotConfigured:
-            return "Firebase 설정이 완료되지 않았습니다. Presentation 타깃 리소스에 GoogleService-Info.plist를 추가해주세요."
+            return "Firebase 설정이 완료되지 않았습니다. Data 타깃 리소스에 GoogleService-Info.plist를 추가해주세요."
         case .missingUserEmail:
             return "로그인한 사용자 정보를 확인할 수 없습니다."
         case .wrongCredentials:


### PR DESCRIPTION
## 📌 PR 설명

### 🔧 변경 내용
- `AuthError.firebaseNotConfigured` 에러 메시지 수정
- Firebase 초기화에 필요한 `GoogleService-Info.plist`의 올바른 타깃(Data) 기준으로 안내하도록 변경

---

### 🐞 문제 상황
기존 에러 메시지에서  
`GoogleService-Info.plist`를 **Presentation 타깃에 추가하라고 잘못 안내**하고 있었음

하지만 실제로 Firebase 초기화는 **Data 타깃 기준으로 수행**되기 때문에  
잘못된 위치에 리소스를 추가하면 Firebase 초기화가 실패할 수 있음

---

### 🎯 수정 목적
- 잘못된 가이드를 수정하여 디버깅 혼선을 방지
- Firebase 초기화 실패 시 올바른 해결 방향 제시

---

### 🔍 변경 전 / 후

#### Before
```swift
"Presentation 타깃 리소스에 GoogleService-Info.plist를 추가해주세요."
```
#### After
```swift
"Data 타깃 리소스에 GoogleService-Info.plist를 추가해주세요."
```
